### PR TITLE
fix: added isRecord to exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,5 @@ export {
   isFunction,
   isObject,
   isArray,
+  isRecord,
 } from "./builtins";


### PR DESCRIPTION
The problem was that `isRecord` was not included in the exports of `src/index.ts`.